### PR TITLE
✨feat: ./node_modules/.bin の zenn コマンドを環境変数 PATH の設定なしで認識する

### DIFF
--- a/src/extension/zenncli/zennCli.ts
+++ b/src/extension/zenncli/zennCli.ts
@@ -23,6 +23,10 @@ export class ZennCli {
         for (let i = 0; i < paths.length; i++) {
             paths[i] = path.resolve(workingDirectory.fsPath, paths[i]);
         }
+        // additional paths
+        paths.unshift(
+            path.join(workingDirectory.fsPath, 'node_modules', '.bin'),
+        );
         return vscode.Uri.file(await which('zenn', { path: env.PATH }));
     }
 


### PR DESCRIPTION
## 関連する Issue

- If i have a locally installed zenn-cli, please use it #1

## 対応方針

- 拡張内部で `zenn` のパスを解決する際に、`<workdir>/node_modules/.bin` を候補に追加する

## 動作確認 ✔️ 

`node_modules/.bin` を `PATH` から削除し、`zenn` を解決できない状態でプレビューが表示されるか確認

```
❯ which zenn
zenn not found
```

⇒ プレビューが表示された