### PR TITLE
Zenn Contents でフィルターを使えるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ vscode-zenn-editor の注目すべき変更はこのファイルで文書化さ�
 ### Fixed
 
 - タイトルを変更したときにコンテンツ一覧での並び順が変わってしまうことがある問題を修正しました [PR#20](https://github.com/negokaz/vscode-zenn-editor/pull/20)
+- 投稿コンテンツの一覧で VSCode のフィルター機能が使えない問題を修正しました [PR#21](https://github.com/negokaz/vscode-zenn-editor/pull/21)
+
+    フィルター機能については、次のページを参照してください
+
+    > Improved keyboard navigation
+    >
+    > [Visual Studio Code January 2019](https://code.visualstudio.com/updates/v1_31#_new-tree-widget)
 
 ## [0.7.0] - 2021-04-29
 [0.7.0]: https://github.com/negokaz/vscode-zenn-editor/compare/v0.6.0...v0.7.0

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -6,6 +6,7 @@ import { ZennTeeViewManager } from './treeView/zennTreeViewManager';
 import { ZennCli } from './zenncli/zennCli';
 import { ZennWorkspace } from './util/zennWorkspace';
 import Uri from './util/uri';
+import * as path from 'path';
 
 const treeViewManager = ZennTeeViewManager.create();
 
@@ -79,9 +80,15 @@ function openImageUploader() {
 }
 
 function openTreeViewItem() {
-    return (uri?: vscode.Uri) => {
+    return async (uri?: vscode.Uri) => {
         if (uri) {
-            vscode.commands.executeCommand('vscode.open', uri, { viewColumn: vscode.ViewColumn.One });
+           try {
+                const doc = await vscode.workspace.openTextDocument(uri);
+                return await vscode.window.showTextDocument(doc, vscode.ViewColumn.One, true);
+            } catch (e) {
+                // 選択したファイルがテキストではない場合
+                vscode.commands.executeCommand('vscode.open', uri, { viewColumn: vscode.ViewColumn.One });
+            }
         }
     }
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -97,10 +97,10 @@ function openTreeViewItem() {
 async function onDidChangeActiveTextEditor(editor: vscode.TextEditor | undefined): Promise<void> {
     if (editor) {
         const uri = Uri.of(editor.document.uri);
-        await Promise.all([
-            treeViewManager.selectItem(uri, /*attemptLimit*/1),
-            previewViewManager.changePreviewDocument(editor.document),
-        ]);
+        const item = await treeViewManager.selectItem(uri, /*attemptLimit*/1);
+        if (item) {
+            await previewViewManager.changePreviewDocument(editor.document);
+        }
     }
 }
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -22,6 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('zenn-editor.create-new-article', createNewArticle()),
 		vscode.commands.registerCommand('zenn-editor.create-new-book', createNewBook()),
         vscode.commands.registerCommand('zenn-editor.open-image-uploader', openImageUploader()),
+        vscode.window.onDidChangeActiveTextEditor(editor => onDidChangeActiveTextEditor(editor)),
         vscode.workspace.onDidCreateFiles(() => onDidCreateFiles()),
         vscode.workspace.onDidDeleteFiles(() => onDidDeleteFiles()),
         vscode.workspace.onDidRenameFiles(() => onDidRenameFiles()),
@@ -90,6 +91,16 @@ function openTreeViewItem() {
                 vscode.commands.executeCommand('vscode.open', uri, { viewColumn: vscode.ViewColumn.One });
             }
         }
+    }
+}
+
+async function onDidChangeActiveTextEditor(editor: vscode.TextEditor | undefined): Promise<void> {
+    if (editor) {
+        const uri = Uri.of(editor.document.uri);
+        await Promise.all([
+            treeViewManager.selectItem(uri, /*attemptLimit*/1),
+            previewViewManager.changePreviewDocument(editor.document),
+        ]);
     }
 }
 

--- a/src/extension/preview/previewView.ts
+++ b/src/extension/preview/previewView.ts
@@ -37,11 +37,6 @@ export default class PreviewView {
         this.webviewPanel = webviewPanel;
         this.disposables.push(
             this.webviewPanel.webview.onDidReceiveMessage(this.receiveWebviewMessage),
-            vscode.window.onDidChangeActiveTextEditor(editor => {
-                if (editor) {
-                    this.handleDidChangeActiveTextEditor(editor)
-                }
-            }),
         );
         this.webviewPanel.onDidDispose(() => {
             this.disposables.forEach(d => d.dispose());
@@ -77,9 +72,9 @@ export default class PreviewView {
         `;
     }
 
-    private async handleDidChangeActiveTextEditor(textEditor: vscode.TextEditor): Promise<void> {
-        if (textEditor.document.languageId === 'markdown') {
-            const document = Uri.of(textEditor.document.uri);
+    public async changePreviewDocument(textDocument: vscode.TextDocument): Promise<void> {
+        if (textDocument.languageId === 'markdown') {
+            const document = Uri.of(textDocument.uri);
             const workspace = document.workspaceDirectory();
             if (workspace) {
                 if (!(this.currentBackend && this.currentBackend.isProvide(document))) {

--- a/src/extension/preview/previewView.ts
+++ b/src/extension/preview/previewView.ts
@@ -10,7 +10,10 @@ export default class PreviewView {
         const panel = vscode.window.createWebviewPanel(
             'zenn-editor.preview',
             'Zenn Editor Preview',
-            vscode.ViewColumn.Two,
+            {
+                viewColumn: vscode.ViewColumn.Two,
+                preserveFocus: true,
+            },
             {
                 enableScripts: true,
                 localResourceRoots: [vscode.Uri.file(context.extensionPath)],

--- a/src/extension/preview/previewView.ts
+++ b/src/extension/preview/previewView.ts
@@ -30,14 +30,21 @@ export default class PreviewView {
 
     private readonly resource: ExtensionResource;
 
+    private disposables: vscode.Disposable[] = [];
+
     private constructor(webviewPanel: vscode.WebviewPanel, resource: ExtensionResource) {
         this.resource = resource;
         this.webviewPanel = webviewPanel;
-        this.webviewPanel.webview.onDidReceiveMessage(this.receiveWebviewMessage);
-        vscode.window.onDidChangeActiveTextEditor(editor => {
-            if (editor) {
-                this.handleDidChangeActiveTextEditor(editor)
-            }
+        this.disposables.push(
+            this.webviewPanel.webview.onDidReceiveMessage(this.receiveWebviewMessage),
+            vscode.window.onDidChangeActiveTextEditor(editor => {
+                if (editor) {
+                    this.handleDidChangeActiveTextEditor(editor)
+                }
+            }),
+        );
+        this.webviewPanel.onDidDispose(() => {
+            this.disposables.forEach(d => d.dispose());
         });
     }
 

--- a/src/extension/preview/previewViewManager.ts
+++ b/src/extension/preview/previewViewManager.ts
@@ -29,4 +29,10 @@ export default class PreviewViewManager {
             this.imageUploaderStatusbarItem.show();
         }
     }
+
+    public async changePreviewDocument(document: vscode.TextDocument): Promise<void> {
+        if (this.previewView) {
+            this.previewView.changePreviewDocument(document);
+        }
+    }
 }

--- a/src/extension/treeView/zennTreeViewManager.ts
+++ b/src/extension/treeView/zennTreeViewManager.ts
@@ -47,13 +47,13 @@ export class ZennTeeViewManager {
         }
     }
 
-    public async selectItem(uri: Uri, attemptLimit = 10): Promise<void> {
-        return new Promise<void>((resolve) => this.innerSelectItem(uri, resolve, attemptLimit));
+    public async selectItem(uri: Uri, attemptLimit = 10): Promise<ZennTreeItem | undefined> {
+        return new Promise<ZennTreeItem | undefined>((resolve) => this.innerSelectItem(uri, resolve, attemptLimit));
     }
 
-    private async innerSelectItem(uri: Uri, resolve: () => void, remain: number): Promise<void> {
+    private async innerSelectItem(uri: Uri, resolve: (value: ZennTreeItem | undefined) => void, remain: number): Promise<void> {
         if (remain === 0) {
-            resolve();
+            resolve(undefined);
         } else {
             if (this.treeViewProvider && this.treeView) {
                 const item = await this.treeViewProvider.findItem(uri);
@@ -63,12 +63,12 @@ export class ZennTeeViewManager {
                         focus: false,
                         expand: true,
                     });
-                    resolve();
+                    resolve(item);
                 } else {
                     setTimeout(() => this.innerSelectItem(uri, resolve, remain - 1), 100/*ms*/);
                 }
             } else {
-                resolve();
+                resolve(undefined);
             }
         }
     }

--- a/src/extension/treeView/zennTreeViewManager.ts
+++ b/src/extension/treeView/zennTreeViewManager.ts
@@ -31,12 +31,6 @@ export class ZennTeeViewManager {
             this.treeView.onDidCollapseElement(e => {
                 e.element.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
             });
-            vscode.window.onDidChangeActiveTextEditor(async event => {
-                if (event && this.treeViewProvider) {
-                    const uri = Uri.of(event.document.uri);
-                    this.selectItem(uri, /*attemptLimit*/1);
-                }
-            });
             if (vscode.window.activeTextEditor) {
                 const uri = Uri.of(vscode.window.activeTextEditor.document.uri);
                 this.selectItem(uri);
@@ -53,7 +47,7 @@ export class ZennTeeViewManager {
         }
     }
 
-    private async selectItem(uri: Uri, attemptLimit = 10): Promise<void> {
+    public async selectItem(uri: Uri, attemptLimit = 10): Promise<void> {
         return new Promise<void>((resolve) => this.innerSelectItem(uri, resolve, attemptLimit));
     }
 


### PR DESCRIPTION
VSCode の TreeView ではフィルターが使える。

**参考**
> Improved keyboard navigation
>
> [Visual Studio Code January 2019](https://code.visualstudio.com/updates/v1_31#_new-tree-widget)

現状の Zenn Editor では TextEditor がフォーカスを奪ってしまうため、このフィルターが使えない状態になっている。
コンテンツを開いたときに TextEditor がフォーカスを奪わないように調整する。