### PR TITLE
🐞fix: webview.asWebviewUri を使って webview.js の URL を解決

### DIFF
--- a/src/extension/preview/previewView.ts
+++ b/src/extension/preview/previewView.ts
@@ -79,7 +79,7 @@ export default class PreviewView {
         return `
             <html>
                 <head>
-                    <script src="${this.resource.uri('dist', 'webview.js')}"></script>
+                    <script src="${this.webviewPanel.webview.asWebviewUri(this.resource.uri('dist', 'webview.js'))}"></script>
                 </head>
                 <body>
                     <div>

--- a/src/extension/resource/extensionResource.ts
+++ b/src/extension/resource/extensionResource.ts
@@ -13,6 +13,6 @@ export default class ExtensionResource {
         const onDiskPath = vscode.Uri.file(
             path.join(this.context.extensionPath, path.join(...pathElements))
         );
-        return onDiskPath.with({ scheme: 'vscode-resource' });
+        return onDiskPath;
     }
 }


### PR DESCRIPTION
devcontainer 環境でプレビューが正しく表示できない問題があったため

#34 